### PR TITLE
Register mime types for eot, otf, and svg

### DIFF
--- a/lib/mathjax/rails.rb
+++ b/lib/mathjax/rails.rb
@@ -1,4 +1,5 @@
 require 'mathjax/rails/helpers'
 require 'mathjax/rails/routes'
 require 'mathjax/rails/controllers'
+require 'mathjax/rails/mime_types'
 require 'mathjax/rails/version'

--- a/lib/mathjax/rails/mime_types.rb
+++ b/lib/mathjax/rails/mime_types.rb
@@ -1,0 +1,3 @@
+Mime::Type.register "application/vnd.ms-fontobject", :eot
+Mime::Type.register "font/opentype", :otf
+Mime::Type.register "image/svg+xml", :svg


### PR DESCRIPTION
Chrome was complaining about the font mime types with this lovely message in the console:

```
Resource interpreted as Font but transferred with MIME type application/octet-stream.
```

This patch ensures the proper mime types are registered and stops the whining.
