### PR TITLE
Prefix mathjax_path with main_app

### DIFF
--- a/lib/mathjax/rails/helpers.rb
+++ b/lib/mathjax/rails/helpers.rb
@@ -4,7 +4,7 @@ module Mathjax
       def mathjax_tag(opt={})
         opt[:config] ||= 'TeX-AMS_HTML-full.js'
         opt[:config] = nil if opt[:config] == false
-      	"<script src=\"#{mathjax_path(:uri=>'MathJax.js', config: opt[:config])}\" type=\"text/javascript\"></script>".html_safe
+        "<script src=\"#{main_app.mathjax_path(:uri=>'MathJax.js', config: opt[:config])}\" type=\"text/javascript\"></script>".html_safe
       end
     end
   end


### PR DESCRIPTION
This can solve the undefined method error when used with Rails engine.
The host application uses MathJax, so the mathjax_path should be
provided by main_app.