### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,7 @@ add the following to config/routes.rb (you can change the name of course):
 
 ``` ruby
 mathjax 'mathjax'
-```
-
-optional cache option:
-
-``` ruby
-mathjax 'mathjax', 30.days
+# mathjax 'mathjax', 1.day #optional cache options, defaults to 1.day
 ```
 
 add the script tag inside app/views/layouts/application.html.erb:

--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ add the following to config/routes.rb (you can change the name of course):
 mathjax 'mathjax'
 ```
 
+optional cache option:
+
+``` ruby
+mathjax 'mathjax', 30.days
+```
+
 add the script tag inside app/views/layouts/application.html.erb:
 
 ``` rhtml

--- a/lib/mathjax/rails/controllers.rb
+++ b/lib/mathjax/rails/controllers.rb
@@ -3,6 +3,10 @@ class Mathjax::Rails::MathjaxRailsController < ActionController::Base
     ext = ''
     ext = ".#{params[:format]}" if params[:format]
     filename = params[:uri]+ext
+
+    clean_path = Pathname.new(filename).cleanpath.to_s
+    return render :status => 404 if clean_path != filename
+
     filepath = "../../../../vendor/#{Mathjax::Rails::DIRNAME}/#{filename}"
 
     extname = File.extname(filename)[1..-1]

--- a/lib/mathjax/rails/controllers.rb
+++ b/lib/mathjax/rails/controllers.rb
@@ -16,7 +16,7 @@ class Mathjax::Rails::MathjaxRailsController < ActionController::Base
     options[:disposition] = 'inline'
     file = File.expand_path(filepath, __FILE__)
     if File.exists?(file)
-      response.headers["Expires"] = (params[:cache] || 1.day).from_now.httpdate
+      expires_in (params[:cache] || 1.day), :public => true unless params[:cache] == false
       send_file file, options
     else
       render :status => 404

--- a/lib/mathjax/rails/controllers.rb
+++ b/lib/mathjax/rails/controllers.rb
@@ -16,6 +16,7 @@ class Mathjax::Rails::MathjaxRailsController < ActionController::Base
     options[:disposition] = 'inline'
     file = File.expand_path(filepath, __FILE__)
     if File.exists?(file)
+      response.headers["Expires"] = (params[:cache] || 1.day).from_now.httpdate
       send_file file, options
     else
       render :status => 404

--- a/lib/mathjax/rails/routes.rb
+++ b/lib/mathjax/rails/routes.rb
@@ -1,8 +1,8 @@
 module Mathjax
   module Rails
     module RouterMethods
-      def mathjax(str)
-        match "#{str}/*uri" => "mathjax/rails/mathjax_rails#giveOutStaticFile",:as=>'mathjax', :via => [:get, :post]
+      def mathjax(str, cache=1.day)
+        match "#{str}/*uri" => "mathjax/rails/mathjax_rails#giveOutStaticFile",:as=>'mathjax', :via => [:get, :post], :cache => cache
       end
     end
   end

--- a/lib/mathjax/rails/version.rb
+++ b/lib/mathjax/rails/version.rb
@@ -1,6 +1,6 @@
 module Mathjax
   module Rails
-    VERSION = '2.6.1'
+    VERSION = '2.6.1-olivervbk'
     MATHJAXVERSION = '2.6.1'
     DIRNAME = 'mathjax'
   end

--- a/mathjax-rails.gemspec
+++ b/mathjax-rails.gemspec
@@ -5,10 +5,10 @@ Gem::Specification.new do |s|
   s.name        = "mathjax-rails"
   s.version     = Mathjax::Rails::VERSION
   s.platform    = Gem::Platform::RUBY
-  s.authors     = ["Minqi Pan", "Manu S Ajith"]
-  s.email       = ["pmq2001@gmail.com", "neo@codingarena.in"]
-  s.homepage    = "https://github.com/pmq20/mathjax-rails"
-  s.summary     = "a simple gem to integrate MathJax with Rails 3"
+  s.authors     = ["Minqi Pan", "Manu S Ajith", 'Oliver Kuster']
+  s.email       = ["pmq2001@gmail.com", "neo@codingarena.in", 'olivervbk@gmail.com']
+  s.homepage    = "https://github.com/olivervbk/mathjax-rails"
+  s.summary     = "FORK of pmq200/mathjax-rails - a simple gem to integrate MathJax with Rails 3"
   s.description = "This gem maintains MathJax at a system-wide directory."
 
   s.required_rubygems_version = ">= 1.3.6"


### PR DESCRIPTION
I've noticed that the function 'def giveOutStaticFile' does not properly sanitize the 'uri' variable:
```
filename = params[:uri]+ext
filepath = "../../../../vendor/#{Mathjax::Rails::DIRNAME}/#{filename}"

extname = File.extname(filename)[1..-1]
mime_type = Mime::Type.lookup_by_extension(extname)
options = Hash.new
options[:type] = mime_type.to_s unless mime_type.nil?
options[:disposition] = 'inline'
file = File.expand_path(filepath, __FILE__)
```

So it is possible to inject URLs like:
`/mathjax/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F../etc/passwd`
or on heroku apps:
`/mathjax/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F../apps/Gemfile`

Please consider that params[:uri] and params[:ext] could be subject to path traversal since both are included in the 'filename' variable.

If there is anything I can help you with, please feel free to ask.