### PR TITLE
Fix path traversal vulnerability

### DIFF
--- a/lib/mathjax/rails/controllers.rb
+++ b/lib/mathjax/rails/controllers.rb
@@ -3,6 +3,10 @@ class Mathjax::Rails::MathjaxRailsController < ActionController::Base
     ext = ''
     ext = ".#{params[:format]}" if params[:format]
     filename = params[:uri]+ext
+
+    clean_path = Pathname.new(filename).cleanpath.to_s
+    return render :status => 404 if clean_path != filename
+
     filepath = "../../../../vendor/#{Mathjax::Rails::DIRNAME}/#{filename}"
 
     extname = File.extname(filename)[1..-1]


### PR DESCRIPTION
I've noticed that the function 'def giveOutStaticFile' does not properly sanitize the 'uri' variable:
```
filename = params[:uri]+ext
filepath = "../../../../vendor/#{Mathjax::Rails::DIRNAME}/#{filename}"

extname = File.extname(filename)[1..-1]
mime_type = Mime::Type.lookup_by_extension(extname)
options = Hash.new
options[:type] = mime_type.to_s unless mime_type.nil?
options[:disposition] = 'inline'
file = File.expand_path(filepath, __FILE__)
```

So it is possible to inject URLs like:
`/mathjax/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F../etc/passwd`
or on heroku apps:
`/mathjax/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F../apps/Gemfile`

Please consider that params[:uri] and params[:ext] could be subject to path traversal since both are included in the 'filename' variable.

If there is anything I can help you with, please feel free to ask.